### PR TITLE
Fix issue #28 on small radius cylinders

### DIFF
--- a/src/mesh_operations.cpp
+++ b/src/mesh_operations.cpp
@@ -499,7 +499,7 @@ Mesh* createMeshFromShape(const Cylinder &cylinder)
   double h = cylinder.length;
 
   const double pi = boost::math::constants::pi<double>();
-  unsigned int tot = tot_for_unit_cylinder * r;
+  unsigned int tot = ceil(tot_for_unit_cylinder * r);
   double phid = pi * 2 / tot;
 
   double circle_edge = phid * r;


### PR DESCRIPTION
I came to this problem through an entirely different issue: Initialize a MoveIt! DepthImageOctomapUpdater takes ages for a turtlebot, because the poles are described as very small radius cylinders: top and h_num become 0 and the loop on line 514 iterates max unsigned int times.

This is the first time I see this code, so please, someone confortable with it, check that I'm not doing something silly!.
